### PR TITLE
[fix] simplify names; add test; fix bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # eventdistributor
 
+[![GoDoc](https://godoc.org/github.com/sharnoff/eventdistributor?status.png)](https://pkg.go.dev/github.com/sharnoff/eventdistributor)
+
 Internal event distribution package for Go.
 
 The implementation uses signalling channels to notify waiting "readers", which can then "consume" an

--- a/distributor.go
+++ b/distributor.go
@@ -130,6 +130,7 @@ func (r *EventReader[T]) Consume() T {
 	idx := int(r.position - r.d.basePosition)
 	value := r.d.buf[idx].value
 	r.d.buf[idx].refcount -= 1
+	r.position += 1
 
 	if idx+1 < len(r.d.buf) {
 		r.d.buf[idx+1].refcount += 1

--- a/distributor_test.go
+++ b/distributor_test.go
@@ -1,0 +1,144 @@
+package eventdistributor_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sharnoff/eventdistributor"
+)
+
+type MyEvent struct {
+	id int
+}
+
+func TestDistibutor(t *testing.T) {
+	var options eventdistributor.Options[MyEvent]
+	var sizeChanges []int
+	options.OnBufsizeChange(func(size int) {
+		sizeChanges = append(sizeChanges, size)
+	})
+	var submitted []MyEvent
+	options.OnSubmit(func(e MyEvent) {
+		submitted = append(submitted, e)
+	})
+	var consumed []MyEvent
+	options.OnFullyConsumed(func(e MyEvent) {
+		consumed = append(consumed, e)
+	})
+
+	distributor := eventdistributor.New(options)
+
+	t.Log("submit w/o consumers should be immediately considered consumed")
+	distributor.Submit(MyEvent{id: 1})
+	require.Equal(t, 1, len(submitted))
+	require.Equal(t, 1, len(consumed))
+
+	t.Log("immediately after subscribe, no events are ready")
+	r1 := distributor.Subscribe()
+	c1 := r1.WaitChan()
+	nowNotReady(t, c1)
+	r2 := distributor.Subscribe()
+	c2 := r2.WaitChan()
+	nowNotReady(t, c2)
+
+	t.Log("submit 2")
+	t.Log("after submit, size changes but nothing is consumed")
+	distributor.Submit(MyEvent{id: 2})
+	require.Equal(t, 1, len(sizeChanges))
+	require.Equal(t, 2, len(submitted))
+	require.Equal(t, 1, len(consumed))
+
+	t.Log("after submit, readers are ready")
+	ready(t, r1)
+	nowReady(t, c1)
+	ready(t, r2)
+	nowReady(t, c2)
+
+	t.Log("consumed is only after all readers consume")
+	e := r1.Consume()
+	require.Equal(t, 2, e.id)
+	require.Equal(t, 1, len(consumed))
+	notReady(t, r1)
+	ready(t, r2)
+	e = r2.Consume()
+	require.Equal(t, 2, e.id)
+	require.Equal(t, 2, len(consumed))
+	notReady(t, r2)
+
+	t.Log("Add another consumer")
+	r3 := distributor.Subscribe()
+	notReady(t, r1)
+	notReady(t, r2)
+	notReady(t, r3)
+
+	t.Log("submit 3")
+	t.Log("only one consumer reads")
+	distributor.Submit(MyEvent{id: 3})
+	ready(t, r1)
+	ready(t, r2)
+	ready(t, r3)
+	e = r1.Consume()
+	notReady(t, r1)
+	require.Equal(t, 3, e.id)
+	require.Equal(t, 2, len(consumed))
+
+	t.Log("submit 4")
+	t.Log("two consumers read")
+	distributor.Submit(MyEvent{id: 4})
+	ready(t, r1)
+	e = r1.Consume()
+	require.Equal(t, 4, e.id)
+	notReady(t, r1)
+	e = r2.Consume()
+	require.Equal(t, 3, e.id)
+	ready(t, r2)
+	require.Equal(t, 2, len(consumed))
+
+	t.Log("three consumers read")
+	distributor.Submit(MyEvent{id: 5})
+	ready(t, r1)
+	e = r1.Consume()
+	require.Equal(t, 5, e.id)
+	notReady(t, r1)
+	e = r2.Consume()
+	require.Equal(t, 4, e.id)
+	ready(t, r2)
+	require.Equal(t, 2, len(consumed))
+	e = r3.Consume()
+	require.Equal(t, 3, e.id)
+	ready(t, r3)
+	require.Equal(t, 3, len(consumed))
+
+	t.Log("new reader doesn't see pending stuff")
+	r4 := distributor.Subscribe()
+	notReady(t, r4)
+
+	t.Log("events are considered consumed when reader unsubscribes")
+	r3.Unsubscribe()
+	require.Equal(t, 4, len(consumed))
+}
+
+func notReady(t *testing.T, reader eventdistributor.Reader[MyEvent]) {
+	nowNotReady(t, reader.WaitChan())
+}
+
+func nowNotReady(t *testing.T, c <-chan struct{}) {
+	select {
+	case <-c:
+		require.True(t, false)
+	default:
+	}
+}
+
+func ready(t *testing.T, reader eventdistributor.Reader[MyEvent]) {
+	nowReady(t, reader.WaitChan())
+}
+
+func nowReady(t *testing.T, c <-chan struct{}) {
+	select {
+	case <-c:
+	default:
+		require.True(t, false)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/sharnoff/eventdistributor
 
 go 1.22.2
+
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/options.go
+++ b/options.go
@@ -1,30 +1,30 @@
 package eventdistributor
 
-// DistributorOptions contains a set of options for EventDistributor initialization.
+// Options contains a set of options for Distributor initialization.
 //
 // The zero value is safe to use.
-type DistributorOptions[T any] struct {
-	modify []func(*EventDistributor[T])
+type Options[T any] struct {
+	modify []func(*Distributor[T])
 }
 
 // OnBufsizeChange adds a callback to the options that will be called whenever the number of items
 // in the buffer changes.
 //
-// NOTE: This is typically called during the EventDistributor's Submit(), Consume(), and
+// NOTE: This is typically called during the Distributor's Submit(), Consume(), and
 // Unsubscribe().
-func (o *DistributorOptions[T]) OnBufsizeChange(callback func(size int)) {
-	o.modify = append(o.modify, func(d *EventDistributor[T]) {
+func (o *Options[T]) OnBufsizeChange(callback func(size int)) {
+	o.modify = append(o.modify, func(d *Distributor[T]) {
 		d.onBufsizeChange = append(d.onBufsizeChange, callback)
 	})
 }
 
 // OnSubmit adds a callback to the options that will be called whenever an item is submitted with
-// (*EventDistributor[T]).Submit().
+// (*Distributor[T]).Submit().
 //
 // In the edge case where an item is immediately ignored because there's no readers, OnSubmit will
 // be called before OnfullyConsumed.
-func (o *DistributorOptions[T]) OnSubmit(callback func(item T)) {
-	o.modify = append(o.modify, func(d *EventDistributor[T]) {
+func (o *Options[T]) OnSubmit(callback func(item T)) {
+	o.modify = append(o.modify, func(d *Distributor[T]) {
 		d.onSubmit = append(d.onSubmit, callback)
 	})
 }
@@ -33,9 +33,9 @@ func (o *DistributorOptions[T]) OnSubmit(callback func(item T)) {
 // from the buffer.
 //
 // NOTE: If there are no active subscribers, the callback will be called *during* the call to
-// (*EventDistributor[T]).Submit().
-func (o *DistributorOptions[T]) OnFullyConsumed(callback func(item T)) {
-	o.modify = append(o.modify, func(d *EventDistributor[T]) {
+// (*Distributor[T]).Submit().
+func (o *Options[T]) OnFullyConsumed(callback func(item T)) {
+	o.modify = append(o.modify, func(d *Distributor[T]) {
 		d.onFullyConsumed = append(d.onFullyConsumed, callback)
 	})
 }


### PR DESCRIPTION
This change has multiple parts.

1. It simplifies names so that "eventdistributor" isn't repeated when.  `eventdistributor.NewEventDistributor` -> `eventdistributor.New`.
2. It adds a test
3. It fixes one critical bug.