### PR TITLE
[chore] eventdistributor works with older versions of Go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sharnoff/eventdistributor
 
-go 1.22.2
+go 1.18
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
Event distributor doesn't require modern Go. It would likely work with ancient Go.